### PR TITLE
Add self-update command to devcontainer.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ VERSION:
    1.0.11
 
 COMMANDS:
-   run        Run container use `docker run`
-   templates  Run `devcontainer templates`
-   start      Run `devcontainer up` and `devcontainer exec`
-   stop       Stop devcontainers.
-   down       Stop and remove devcontainers.
-   config     devcontainer.vim's config information.
-   vimrc      devcontainer.vim's vimrc information.
-   runargs    run subcommand's default arguments.
-   tool       Management tools
-   clean      clean workspace cache files.
-   index      Management index file
-   self-update Update devcontainer.vim itself
-   help, h    Shows a list of commands or help for one command
+   run          Run container use `docker run`
+   templates    Run `devcontainer templates`
+   start        Run `devcontainer up` and `devcontainer exec`
+   stop         Stop devcontainers.
+   down         Stop and remove devcontainers.
+   config       devcontainer.vim's config information.
+   vimrc        devcontainer.vim's vimrc information.
+   runargs      run subcommand's default arguments.
+   tool         Management tools
+   clean        clean workspace cache files.
+   index        Management index file
+   self-update  Update devcontainer.vim itself
+   help, h      Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --license, -l  show licensesa.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ COMMANDS:
    tool       Management tools
    clean      clean workspace cache files.
    index      Management index file
+   self-update Update devcontainer.vim itself
    help, h    Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
@@ -105,6 +106,13 @@ devcontainer.vim tool vim download
 devcontainer.vim tool devcontainer download
 ```
 
+#### devcontainer.vim 自身のアップデート
+
+`self-update` サブコマンドを使用して、 `devcontainer.vim` 自身を最新バージョンに更新できます。
+
+```sh
+devcontainer.vim self-update
+```
 
 ### テンプレートをもとに `devcontainer.json` を作成する
 

--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func main() {
 							// Features の一覧をダウンロード
 							indexFileName := "devcontainer-index.json"
 							indexFile := filepath.Join(appCacheDir, indexFileName)
-							if !util.IsExists(indexFile) {
+							if (!util.IsExists(indexFile)) {
 								fmt.Println("Download template index ... ")
 								oras.Pull("ghcr.io/devcontainers/index", "latest", appCacheDir)
 								fmt.Println("done.")
@@ -632,6 +632,41 @@ func main() {
 							return nil
 						},
 					},
+				},
+			},
+			{
+				Name:      "self-update",
+				Usage:     "Update devcontainer.vim itself",
+				UsageText: "devcontainer.vim self-update",
+				Action: func(cCtx *cli.Context) error {
+					// Get the latest release tag name from GitHub
+					latestTagName, err := util.GetLatestReleaseFromGitHub("mikoto2000", "devcontainer.vim")
+					if err != nil {
+						panic(err)
+					}
+
+					// Construct the download URL for the latest release
+					var downloadURL string
+					if runtime.GOOS == "windows" {
+						downloadURL = fmt.Sprintf("https://github.com/mikoto2000/devcontainer.vim/releases/download/%s/devcontainer.vim-windows-amd64.exe", latestTagName)
+					} else if runtime.GOOS == "darwin" {
+						downloadURL = fmt.Sprintf("https://github.com/mikoto2000/devcontainer.vim/releases/download/%s/devcontainer.vim-darwin-amd64", latestTagName)
+					} else {
+						downloadURL = fmt.Sprintf("https://github.com/mikoto2000/devcontainer.vim/releases/download/%s/devcontainer.vim-linux-amd64", latestTagName)
+					}
+
+					// Download the latest release
+					executablePath, err := os.Executable()
+					if err != nil {
+						panic(err)
+					}
+					err = tools.DownloadFile(downloadURL, executablePath)
+					if err != nil {
+						panic(err)
+					}
+
+					fmt.Println("devcontainer.vim has been updated to the latest version.")
+					return nil
 				},
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 	// vimrc ファイルの出力先を組み立て
 	// vimrc を出力(既に存在するなら何もしない)
 	vimrc := filepath.Join(appConfigDir, "vimrc")
-	if !util.IsExists(vimrc) {
+	if (!util.IsExists(vimrc)) {
 		err := util.CreateFileWithContents(vimrc, additionalVimrc, 0666)
 		if err != nil {
 			panic(err)
@@ -91,7 +91,7 @@ func main() {
 	// runargs ファイルの出力先を組み立て
 	// runargs を出力(既に存在するなら何もしない)
 	runargs := filepath.Join(appConfigDir, "runargs")
-	if !util.IsExists(runargs) {
+	if (!util.IsExists(runargs)) {
 		err := util.CreateFileWithContents(runargs, runargsContent, 0666)
 		if err != nil {
 			panic(err)
@@ -639,33 +639,10 @@ func main() {
 				Usage:     "Update devcontainer.vim itself",
 				UsageText: "devcontainer.vim self-update",
 				Action: func(cCtx *cli.Context) error {
-					// Get the latest release tag name from GitHub
-					latestTagName, err := util.GetLatestReleaseFromGitHub("mikoto2000", "devcontainer.vim")
+					err := tools.SelfUpdate()
 					if err != nil {
 						panic(err)
 					}
-
-					// Construct the download URL for the latest release
-					var downloadURL string
-					if runtime.GOOS == "windows" {
-						downloadURL = fmt.Sprintf("https://github.com/mikoto2000/devcontainer.vim/releases/download/%s/devcontainer.vim-windows-amd64.exe", latestTagName)
-					} else if runtime.GOOS == "darwin" {
-						downloadURL = fmt.Sprintf("https://github.com/mikoto2000/devcontainer.vim/releases/download/%s/devcontainer.vim-darwin-amd64", latestTagName)
-					} else {
-						downloadURL = fmt.Sprintf("https://github.com/mikoto2000/devcontainer.vim/releases/download/%s/devcontainer.vim-linux-amd64", latestTagName)
-					}
-
-					// Download the latest release
-					executablePath, err := os.Executable()
-					if err != nil {
-						panic(err)
-					}
-					err = tools.DownloadFile(downloadURL, executablePath)
-					if err != nil {
-						panic(err)
-					}
-
-					fmt.Println("devcontainer.vim has been updated to the latest version.")
 					return nil
 				},
 			},

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -194,3 +194,35 @@ func InstallDownTools(installDir string) (string, error) {
 	devcontainerPath, err := DEVCONTAINER.Install(installDir, false)
 	return devcontainerPath, err
 }
+
+// SelfUpdate downloads the latest release of devcontainer.vim from GitHub and replaces the current binary
+func SelfUpdate() error {
+	// Get the latest release tag name from GitHub
+	latestTagName, err := util.GetLatestReleaseFromGitHub("mikoto2000", "devcontainer.vim")
+	if err != nil {
+		return err
+	}
+
+	// Construct the download URL for the latest release
+	var downloadURL string
+	if runtime.GOOS == "windows" {
+		downloadURL = fmt.Sprintf("https://github.com/mikoto2000/devcontainer.vim/releases/download/%s/devcontainer.vim-windows-amd64.exe", latestTagName)
+	} else if runtime.GOOS == "darwin" {
+		downloadURL = fmt.Sprintf("https://github.com/mikoto2000/devcontainer.vim/releases/download/%s/devcontainer.vim-darwin-amd64", latestTagName)
+	} else {
+		downloadURL = fmt.Sprintf("https://github.com/mikoto2000/devcontainer.vim/releases/download/%s/devcontainer.vim-linux-amd64", latestTagName)
+	}
+
+	// Download the latest release
+	executablePath, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	err = download(downloadURL, executablePath)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("devcontainer.vim has been updated to the latest version.")
+	return nil
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -227,7 +227,7 @@ func SelfUpdate() error {
 		return err
 	}
 
-	err = download(downloadURL, executablePath)
+	_, err = simpleInstall(downloadURL, executablePath)
 	if err != nil {
 		// Restore the original binary if download fails
 		os.Rename(tempPath, executablePath)


### PR DESCRIPTION
Add self-update feature to devcontainer.vim.

* **main.go**
  - Add a new command `self-update` to update `devcontainer.vim` itself.
  - Implement the `self-update` command to download the latest release of `devcontainer.vim` from GitHub and replace the current binary.

* **README.md**
  - Update the `README.md` to include instructions for using the `self-update` command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mikoto2000/devcontainer.vim?shareId=669f5c00-6ad6-4d1d-af8d-a16d47e3e6c0).