### PR TITLE
Add subcommand completion feature

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,3 +30,22 @@ docker run -it --rm -v "$(pwd):/work" --workdir /work --name devcontainer.vim go
 go mod init github.com/mikoto2000/devcontainer.vim
 ```
 
+## Generate and Use Completion Scripts
+
+### Bash
+
+```sh
+source <(devcontainer.vim completion bash)
+```
+
+### Zsh
+
+```sh
+source <(devcontainer.vim completion zsh)
+```
+
+### Fish
+
+```sh
+devcontainer.vim completion fish | source
+```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ COMMANDS:
    clean        clean workspace cache files.
    index        Management index file
    self-update  Update devcontainer.vim itself
+   completion   Generate completion script
    help, h      Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
@@ -133,6 +134,38 @@ Search: Go
 `devcontainer.vim templates apply` を実行すると、テンプレート名の一覧が表示されるので、
 キー入力で名前をインクリメンタル検索し、上下キーでカーソルを移動・エンターキーでテンプレートを決定できる。
 
+
+### サブコマンド補完機能の追加
+
+`devcontainer.vim` には、サブコマンド補完機能が追加されました。これにより、シェルでのコマンド入力がより簡単になります。
+
+#### 補完スクリプトの生成
+
+以下のコマンドを使用して、補完スクリプトを生成できます。
+
+```sh
+devcontainer.vim completion [bash|zsh|fish]
+```
+
+生成されたスクリプトをシェルの設定ファイルに追加することで、補完機能を有効にできます。
+
+#### Bash の場合
+
+```sh
+source <(devcontainer.vim completion bash)
+```
+
+#### Zsh の場合
+
+```sh
+source <(devcontainer.vim completion zsh)
+```
+
+#### Fish の場合
+
+```sh
+devcontainer.vim completion fish | source
+```
 
 ## Customize:
 

--- a/main.go
+++ b/main.go
@@ -99,11 +99,17 @@ func main() {
 		fmt.Printf("Generated additional runargs to: %s\n", runargs)
 	}
 
+	// Check if COMP_LINE environment variable is set
+	if os.Getenv("COMP_LINE") != "" {
+		completeSubcommands()
+		return
+	}
+
 	devcontainerVimArgProcess := (&cli.App{
 		Name:                   "devcontainer.vim",
 		Usage:                  "devcontainer for vim.",
 		Version:                version,
-		UseShortOptionHandling: true,
+			UseShortOptionHandling: true,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:               flagNameLicense,
@@ -646,6 +652,25 @@ func main() {
 					return nil
 				},
 			},
+			{
+				Name:      "completion",
+				Usage:     "Generate completion script",
+				UsageText: "devcontainer.vim completion [bash|zsh|fish]",
+				Action: func(cCtx *cli.Context) error {
+					shell := cCtx.Args().First()
+					switch shell {
+					case "bash":
+						fmt.Println(cli.BashCompletionScript)
+					case "zsh":
+						fmt.Println(cli.ZshCompletionScript)
+					case "fish":
+						fmt.Println(cli.FishCompletionScript)
+					default:
+						fmt.Println("Unsupported shell. Please use bash, zsh, or fish.")
+					}
+					return nil
+				},
+			},
 		},
 	})
 
@@ -676,4 +701,52 @@ func createConfigFile(devcontainerPath string, workspaceFolder string, configDir
 	fmt.Printf("Use configuration file: `%s`", mergedConfigFilePath)
 
 	return mergedConfigFilePath, err
+}
+
+// completeSubcommands handles subcommand completion
+func completeSubcommands() {
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		{
+			Name: "run",
+		},
+		{
+			Name: "templates",
+		},
+		{
+			Name: "start",
+		},
+		{
+			Name: "stop",
+		},
+		{
+			Name: "down",
+		},
+		{
+			Name: "config",
+		},
+		{
+			Name: "vimrc",
+		},
+		{
+			Name: "runargs",
+		},
+		{
+			Name: "tool",
+		},
+		{
+			Name: "clean",
+		},
+		{
+			Name: "index",
+		},
+		{
+			Name: "self-update",
+		},
+		{
+			Name: "completion",
+		},
+	}
+
+	app.Run(os.Args)
 }


### PR DESCRIPTION
Add subcommand completion feature to `devcontainer.vim`.

* **main.go**
  - Add a new function `completeSubcommands` to handle subcommand completion.
  - Modify the `main` function to call `completeSubcommands` if the `COMP_LINE` environment variable is set.
  - Add a new command `completion` to the CLI app to generate completion scripts for bash, zsh, and fish.

* **README.md**
  - Add a section about the new subcommand completion feature.
  - Update the usage section to include the `completion` command.

* **DEVELOPMENT.md**
  - Add instructions on how to generate and use the completion scripts for bash, zsh, and fish.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mikoto2000/devcontainer.vim?shareId=e5207754-37ff-4171-b0ee-1af506207bd7).