### PR TITLE
Support nested subcommands in bash completion

### DIFF
--- a/bash_complete_func.bash
+++ b/bash_complete_func.bash
@@ -1,8 +1,45 @@
 _completion_devcontainer_vim(){
     local prev cur cword
     _get_comp_words_by_ref -n : cur prev cword
-    opts="run templates start stop down config vimrc runargs tool clean index self-update help"
-    COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+
+    local commands="run templates start stop down config vimrc runargs tool clean index self-update help"
+    local subcommands_run=""
+    local subcommands_templates="apply"
+    local subcommands_tool="vim devcontainer clipboard-data-receiver"
+    local subcommands_tool_vim="download"
+    local subcommands_tool_devcontainer="download"
+    local subcommands_tool_clipboard_data_receiver="download"
+    local subcommands_index="update"
+
+    if [[ ${cword} -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "${commands}" -- "${cur}") )
+    else
+        case "${prev}" in
+            run)
+                COMPREPLY=( $(compgen -W "${subcommands_run}" -- "${cur}") )
+                ;;
+            templates)
+                COMPREPLY=( $(compgen -W "${subcommands_templates}" -- "${cur}") )
+                ;;
+            tool)
+                COMPREPLY=( $(compgen -W "${subcommands_tool}" -- "${cur}") )
+                ;;
+            vim)
+                COMPREPLY=( $(compgen -W "${subcommands_tool_vim}" -- "${cur}") )
+                ;;
+            devcontainer)
+                COMPREPLY=( $(compgen -W "${subcommands_tool_devcontainer}" -- "${cur}") )
+                ;;
+            clipboard-data-receiver)
+                COMPREPLY=( $(compgen -W "${subcommands_tool_clipboard_data_receiver}" -- "${cur}") )
+                ;;
+            index)
+                COMPREPLY=( $(compgen -W "${subcommands_index}" -- "${cur}") )
+                ;;
+            *)
+                COMPREPLY=()
+                ;;
+        esac
+    fi
 } &&
 complete -F _completion_devcontainer_vim devcontainer.vim bash-complete-func
-


### PR DESCRIPTION
Update the `_completion_devcontainer_vim` function in `bash_complete_func.bash` to support nested subcommands for `devcontainer.vim`.

* Add local variables for commands and subcommands.
* Modify the function to dynamically complete subcommands based on the current context.
* Remove the static `opts` variable and replace it with dynamic completion logic.
* Update the `complete` command to use the modified `_completion_devcontainer_vim` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mikoto2000/devcontainer.vim?shareId=c068e847-929d-47ea-a120-ba9c9c967269).