### PR TITLE
Refactor error handling to return errors instead of using panic

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -150,6 +151,9 @@ func GetContainerIDFromWorkspaceFolder(workspaceFolder string) (string, error) {
 	}
 
 	psResult, err := Ps("label=devcontainer.local_folder=" + workspaceFilderAbs)
+	if psResult == "" {
+		return "", errors.New("container not found.")
+	}
 	if err != nil {
 		return "", err
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -18,7 +18,7 @@ const containerCommand = "docker"
 var dockerRunArgsPrefix = []string{"run", "-d", "--rm"}
 var dockerRunArgsSuffix = []string{"sh", "-c", "trap \"exit 0\" TERM; sleep infinity & wait"}
 
-func Run(args []string, vimFilePath string, cdrPath string, configDirForDocker string, vimrc string, defaultRunargs []string) {
+func Run(args []string, vimFilePath string, cdrPath string, configDirForDocker string, vimrc string, defaultRunargs []string) error {
 	vimFileName := filepath.Base(vimFilePath)
 
 	// バックグラウンドでコンテナを起動
@@ -37,7 +37,7 @@ func Run(args []string, vimFilePath string, cdrPath string, configDirForDocker s
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Container start error.")
 		fmt.Fprintln(os.Stderr, string(containerID))
-		panic(err)
+		return err
 	}
 	containerID = strings.ReplaceAll(containerID, "\n", "")
 	containerID = strings.ReplaceAll(containerID, "\r", "")
@@ -47,11 +47,11 @@ func Run(args []string, vimFilePath string, cdrPath string, configDirForDocker s
 	configDirForCdr := filepath.Join(configDirForDocker, containerID)
 	err = os.MkdirAll(configDirForCdr, 0744)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	pid, port, err := tools.RunCdr(cdrPath, configDirForCdr)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	fmt.Printf("Started clipboard-data-receiver with pid: %d, port: %d\n", pid, port)
 
@@ -59,7 +59,7 @@ func Run(args []string, vimFilePath string, cdrPath string, configDirForDocker s
 	// `docker cp <os.UserCacheDir/devcontainer.vim/Vim-AppImage> <dockerrun 時に標準出力に表示される CONTAINER ID>:/`
 	err = Cp("AppImage", vimFilePath, containerID, "/")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// `docker exec <dockerrun 時に標準出力に表示される CONTAINER ID> chmod +x /Vim-AppImage`
@@ -69,26 +69,26 @@ func Run(args []string, vimFilePath string, cdrPath string, configDirForDocker s
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "chmod error.")
 		fmt.Fprintln(os.Stderr, string(chmodResult))
-		panic(err)
+		return err
 	}
 	fmt.Printf(" done.\n")
 
 	// Vim 関連ファイルの転送(`SendToTcp.vim` と、追加の `vimrc`)
 	sendToTCP, err := tools.CreateSendToTCP(configDirForDocker, port)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// コンテナへ SendToTcp.vim を転送
 	err = Cp("SendToTcp.vim", sendToTCP, containerID, "/")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// コンテナへ vimrc を転送
 	err = Cp("vimrc", vimrc, containerID, "/")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// コンテナへ接続
@@ -123,15 +123,20 @@ func Run(args []string, vimFilePath string, cdrPath string, configDirForDocker s
 	fmt.Printf("Stop container(Async) %s.\n", containerID)
 	err = exec.Command(containerCommand, "stop", containerID).Start()
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// clipboard-data-receiver を停止
-	tools.KillCdr(pid)
+	err = tools.KillCdr(pid)
+	if err != nil {
+		return err
+	}
 	err = os.RemoveAll(configDirForCdr)
 	if err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
 // workspaceFolder で指定したディレクトリに対応するコンテナのコンテナ ID を返却する


### PR DESCRIPTION
Refactor error handling to remove `panic` calls and propagate errors to `main.go`.

* **devcontainer/devcontainer.go**
  - Change functions `ExecuteDevcontainer`, `Stop`, `Down`, `findDockerComposeFileDir` to return errors instead of using `panic`.
  - Update error handling in these functions to return errors instead of calling `panic`.

* **docker/docker.go**
  - Change functions `Run`, `GetContainerIDFromWorkspaceFolder`, `Ps`, `Stop`, `Rm`, `Cp` to return errors instead of using `panic`.
  - Update error handling in these functions to return errors instead of calling `panic`.

* **tools/clipboard-data-receiver.go**
  - Change functions `RunCdr`, `runCdrForNative`, `runCdrForWsl`, `KillCdr`, `CreateSendToTCP` to return errors instead of using `panic`.
  - Update error handling in these functions to return errors instead of calling `panic`.

* **main.go**
  - Update error handling to print error messages and call `panic` if necessary.
  - Handle errors returned from other functions and print error messages before calling `panic`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mikoto2000/devcontainer.vim?shareId=a3256a33-70e1-4ab1-b71a-6c6140e13b92).