### PR TITLE
Update error handling in main.go

### DIFF
--- a/devcontainer/devcontainer.go
+++ b/devcontainer/devcontainer.go
@@ -21,6 +21,14 @@ const containerCommand = "docker"
 
 var devcontainreArgsPrefix = []string{"up"}
 
+type UnknownTypeError struct {
+	msg string
+}
+
+func (e *UnknownTypeError) Error() string {
+	return e.msg
+}
+
 // devcontainer でコンテナを立ち上げ、 Vim を転送し、実行する。
 // 既存実装の都合上、configFilePath から configDirForDevcontainer を抽出している
 func ExecuteDevcontainer(args []string, devcontainerPath string, vimFilePath string, cdrPath, configFilePath string, vimrc string) error {
@@ -359,7 +367,7 @@ func findDockerComposeFileDir() (string, error) {
 		vv := v[0].(string)
 		dockerComposeFilePath = filepath.Join(devcontainerJSONDir, vv)
 	default:
-		return "", errors.New("unknown type")
+		return "", &UnknownTypeError{msg: "unknown type"}
 	}
 	dockerComposeFileDir := filepath.Dir(dockerComposeFilePath)
 

--- a/devcontainer/readConfigurationResult.go
+++ b/devcontainer/readConfigurationResult.go
@@ -2,8 +2,15 @@ package devcontainer
 
 import (
 	"encoding/json"
-	"errors"
 )
+
+type ReadConfigurationError struct {
+	msg string
+}
+
+func (e *ReadConfigurationError) Error() string {
+	return e.msg
+}
 
 // `devcontainers read-configuration` コマンドの実行結果スキーマ
 //
@@ -42,7 +49,7 @@ type ConfigFilePath struct {
 func GetConfigFilePath(readConfigurationCommandResult string) (string, error) {
 	result, err := UnmarshalReadConfigurationCommandResult([]byte(readConfigurationCommandResult))
 	if err != nil {
-		return "", errors.New("`devcontainer read-configuration` の出力パースに失敗しました。`.devcontainer.json が存在することと、 docker エンジンが起動していることを確認してください。")
+		return "", &ReadConfigurationError{msg: "`devcontainer read-configuration` の出力パースに失敗しました。`.devcontainer.json が存在することと、 docker エンジンが起動していることを確認してください。"}
 	}
 
 	return result.Configuration.ConfigFilePath.FsPath, nil

--- a/dockercompose/dockerCompose.go
+++ b/dockercompose/dockerCompose.go
@@ -5,20 +5,44 @@ import (
 	"os/exec"
 )
 
+type PsCommandError struct {
+	msg string
+}
+
+func (e *PsCommandError) Error() string {
+	return e.msg
+}
+
+type StopCommandError struct {
+	msg string
+}
+
+func (e *StopCommandError) Error() string {
+	return e.msg
+}
+
+type DownCommandError struct {
+	msg string
+}
+
+func (e *DownCommandError) Error() string {
+	return e.msg
+}
+
 // `docker compose ps --format json` を実行し、結果の文字列を返却する。
 func Ps(workspaceFolder string) (string, error) {
 
 	// 現在のディレクトリを記憶
 	currentDirectory, err := os.Getwd()
 	if err != nil {
-		return "", err
+		return "", &PsCommandError{msg: "Failed to get current directory"}
 	}
 
 	// 元のディレクトリへ戻る
 	defer func() error {
 		err := os.Chdir(currentDirectory)
 		if err != nil {
-			return err
+			return &PsCommandError{msg: "Failed to change directory"}
 		}
 		return nil
 	}()
@@ -26,7 +50,7 @@ func Ps(workspaceFolder string) (string, error) {
 	// ワークスペースまで移動
 	err = os.Chdir(workspaceFolder)
 	if err != nil {
-		return "", err
+		return "", &PsCommandError{msg: "Failed to change to workspace directory"}
 	}
 
 	dockerComposePsCommand := exec.Command("docker", "compose", "ps", "--format", "json")
@@ -37,11 +61,19 @@ func Ps(workspaceFolder string) (string, error) {
 // `docker compose -p ${projectName} stop` を実行する。
 func Stop(projectName string) error {
 	dockerComposeStopCommand := exec.Command("docker", "compose", "-p", projectName, "stop")
-	return dockerComposeStopCommand.Start()
+	err := dockerComposeStopCommand.Start()
+	if err != nil {
+		return &StopCommandError{msg: "Failed to execute docker compose stop command"}
+	}
+	return nil
 }
 
 // `docker compose -p ${projectName} down` を実行する。
 func Down(projectName string) error {
 	dockerComposeDownCommand := exec.Command("docker", "compose", "-p", projectName, "down")
-	return dockerComposeDownCommand.Start()
+	err := dockerComposeDownCommand.Start()
+	if err != nil {
+		return &DownCommandError{msg: "Failed to execute docker compose down command"}
+	}
+	return nil
 }


### PR DESCRIPTION
Update `main.go` to differentiate error messages based on the type of error.

* **Error Handling in `main.go`**
  - Add error type checks and corresponding messages for various error scenarios.
  - Print specific error messages for different error types, such as `os.ErrNotExist` and `os.ErrPermission`.

* **Define Custom Error Types**
  - Define custom error types in `devcontainer/devcontainer.go`, `docker/docker.go`, `dockercompose/dockerCompose.go`, and `devcontainer/readConfigurationResult.go`.
  - Replace `errors.New` with the defined custom error types.

* **Update Error Handling in `devcontainer/devcontainer.go`**
  - Replace generic error messages with custom error types for unknown type errors.

* **Update Error Handling in `docker/docker.go`**
  - Replace generic error messages with custom error types for container start errors, chmod errors, and container not found errors.

* **Update Error Handling in `dockercompose/dockerCompose.go`**
  - Replace generic error messages with custom error types for ps command errors, stop command errors, and down command errors.

* **Update Error Handling in `devcontainer/readConfigurationResult.go`**
  - Replace generic error messages with custom error types for read configuration errors.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mikoto2000/devcontainer.vim?shareId=64d83ff6-1029-42cc-80e4-a37f687b07ad).